### PR TITLE
Add PHP 5.4+ requirement to composer,json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,7 @@
         }
     ],
     "require":{
+        "php": ">=5.4",
         "magento-hackathon/magento-composer-installer":"*"
     }
 }


### PR DESCRIPTION
Since there exist usages of the short array syntax, we also need the composer.json file to specify PHP 5.4+ as a requirement.

See issue #6 